### PR TITLE
build: autogen: simplify

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,19 +1,2 @@
-#! /bin/sh
-
-TOPDIR=$(pwd)
-
-export TOPDIR
-
-[ -f Makefile ] && make -i maintainer-clean
-
-rm --verbose --recursive --force autom4te.cache
-find ${TOPDIR} -name 'Makefile.in' -exec rm --verbose \{\} \;
-
-aclocal --warnings=all -I m4
-automake --verbose --add-missing --gnu
-autoreconf --verbose --warnings=all
-
-rm -f configure.scan *~ *.log
-find ${TOPDIR} -name '*~' -exec rm -f '{}' \;
-
-exit 0
+#!/bin/sh
+autoreconf -ivf


### PR DESCRIPTION
these days autogen is not required as single autoreconf does all work,
in the past it was a complex process hence this script is required.

git clean -dxf will also cleanup all unneeded files for development, so
no reason to manually clean files.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>