### PR TITLE
build: move warning to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,3 +70,5 @@ AC_CONFIG_FILES([
 	iprange.spec
 ])
 AC_OUTPUT
+
+test "${with_compare_with_common}" != "yes" && AC_MSG_WARN([COMPARE_WITH_COMMON is not enabled. You should enable it, as it is a lot faster.]) || :

--- a/iprange.c
+++ b/iprange.c
@@ -24,10 +24,6 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#ifndef COMPARE_WITH_COMMON
-#warning "COMPARE_WITH_COMMON is not enabled. You should enable it, as it is a lot faster."
-#endif
-
 /*
  * the maximum line element to read in input files
  * normally the elements are IP, IP/MASK, HOSTNAME


### PR DESCRIPTION
all customization/warning/interaction should be at autoconf level

compile time is too late.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>