### PR TITLE
dns: print failure message when EAI_AGAIN retries are exhausted

### DIFF
--- a/src/ipset_dns.c
+++ b/src/ipset_dns.c
@@ -147,6 +147,8 @@ static void dns_request_failed(DNSREQ *d, int added, int gai_error)
                 dns_unlock_requests();
                 return;
             }
+            if(!dns_silent)
+                fprintf(stderr, "%s: DNS: '%s' failed permanently after retries: %s\n", PROG, d->hostname, gai_strerror(gai_error));
             dns_request_done(d, added);
             return;
 


### PR DESCRIPTION
## Summary

When `getaddrinfo` returns `EAI_AGAIN` ("Temporary failure in name resolution"), `iprange` retries the request up to 20 times. After the last retry the request was silently completed — no final diagnostic was printed, even though the overall command still exits non-zero.

On systems without network connectivity (e.g. distribution package build VMs, as reported in #42 for openSUSE), the user sees twenty `will be retried` lines and then nothing. It also breaks `tests.d/64-dns-failure-exit-status`, which greps stderr for `failed permanently` — a string only emitted on the `EAI_NONAME` path.

This change mirrors the `EAI_NONAME` branch and emits a `failed permanently after retries` message before completing the request, so both the user and the test get a clear final error regardless of whether the resolver reached a server.

Fixes #42

## Test plan

- [x] `make` clean in `build-default/`
- [x] Full suite (93 tests) green on a machine with working DNS
- [x] `tests.d/64-dns-failure-exit-status` passes inside an offline network namespace (`unshare -r -n`)
- [x] Manual offline run prints the new `failed permanently after retries` line and exits 1