### PR TITLE
Fix release asset upload for github-script v7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,7 +168,7 @@ jobs:
               const release_id = '${{ steps.create_release.outputs.id }}';
               for (let file of await fs.readdirSync('./')) {
                  console.log('uploadReleaseAsset', file);
-                 await github.repos.uploadReleaseAsset({
+                 await github.rest.repos.uploadReleaseAsset({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     release_id: release_id,


### PR DESCRIPTION
## Problem

The `publish` workflow's asset-upload step fails on every tagged release. After the draft release is created, the **Upload** step errors with:

```
TypeError: Cannot read properties of undefined (reading 'uploadReleaseAsset')
```

### Root cause

When the workflow actions were pinned to commit SHAs, `actions/github-script` was pinned to a **v7** commit (`3a2844b7…`). In github-script v5+, the Octokit REST methods moved from `github.*` to `github.rest.*`. The inline upload script still calls `github.repos.uploadReleaseAsset`, which is `undefined` on v7 — so the step throws and no assets are attached.

The release is still created and tarballs are still built and uploaded as workflow artifacts; only the attach-to-release step fails.

### Fix

Call `github.rest.repos.uploadReleaseAsset` instead. One line.

```diff
-                 await github.repos.uploadReleaseAsset({
+                 await github.rest.repos.uploadReleaseAsset({
```

The sibling `Create Release` step uses `actions/create-release` (not github-script) and is unaffected.