### PR TITLE
Add Codacy configuration to exclude test code from metrics

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,27 @@
+---
+exclude_paths:
+  - "tests.build.d/02-vpath-build-after-in-tree-build/cmd.sh"
+  - "tests.build.d/08-portable-u128-build/cmd.sh"
+engines:
+  duplication:
+    exclude_paths:
+      - "run-build-tests.sh"
+      - "run-sanitizer-tests.sh"
+      - "run-tests.sh"
+      - "run-unit-tests.sh"
+      - "tests.build.d/**"
+      - "tests.d/**"
+      - "tests.sanitizers.d/**"
+      - "tests.tsan.d/**"
+      - "tests.unit/**"
+  metric:
+    exclude_paths:
+      - "run-build-tests.sh"
+      - "run-sanitizer-tests.sh"
+      - "run-tests.sh"
+      - "run-unit-tests.sh"
+      - "tests.build.d/**"
+      - "tests.d/**"
+      - "tests.sanitizers.d/**"
+      - "tests.tsan.d/**"
+      - "tests.unit/**"


### PR DESCRIPTION
## What

Adds a committed `.codacy.yml` so Codacy Cloud applies the intended path exclusions. Until now the file existed only locally (uncommitted), so it had **no effect** — Codacy reads its config from the committed default branch.

## Why

Codacy currently analyzes all 188 source/test files, so **test code inflates the duplication and complexity metrics** (Duplication ~9%). This config keeps test directories and test runner scripts out of the `duplication` and `metric` engines only — quality and security tools still analyze test code.

## Exclusions

- **`metric` + `duplication` engines** — `tests.d/**`, `tests.build.d/**`, `tests.sanitizers.d/**`, `tests.tsan.d/**`, `tests.unit/**`, and the `run-*.sh` runners
- **All engines** — two build-test scripts (`tests.build.d/02-…/cmd.sh`, `tests.build.d/08-…/cmd.sh`). These match the repository's existing ignore settings (verified against the Codacy API: they are the only two analyzable files Codacy currently excludes), so committing this file preserves them rather than re-enabling analysis.

## Effect

No change to issues (repo is at 0). Duplication/complexity scores will reflect product code only after the next analysis.